### PR TITLE
 - correct casing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ description = "Tool to work with microtiter plate data."
 authors = ["haeussma <83341109+haeussma@users.noreply.github.com>"]
 license = "MIT License"
 readme = "README.md"
-packages = [{ include = "mtphandler" }]
-include = ["mtphandler/units/ontomaps.toml"]
+packages = [{ include = "MTPHandler" }]
+include = ["MTPHandler/units/ontomaps.toml"]
 
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
this fixes an issue where: 

```bash
python -m build . 
``` 

or 

```bash
pip install -e . 
```

fails